### PR TITLE
Made the rsync task idempotent

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: restart etcd
+- name: Restart etcd
   service: name=etcd
            state=restarted
            enabled=yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,35 +1,35 @@
 ---
-- name: download etcd
+- name: Download etcd
   get_url: url={{ etcd_download_url }}
            dest={{ etcd_download_dir }}/{{ etcd_download_filename }}
            sha256sum={{ etcd_checksum }}
 
-- name: unarchive etcd
+- name: Unarchive etcd
   unarchive: copy=no
              src={{ etcd_download_dir }}/{{ etcd_download_filename }}
              dest={{ etcd_download_dir }}
              creates="{{ etcd_download_dir }}/{{ etcd_release }}/etcd"
 
-# TODO(retr0h): Sucks the `copy` module doesn't do this.
-#               We get idempotency from `rsync(1)`.
-- name: copy binaries from archive into etcd dir
-  shell: rsync -auv {{ etcd_download_dir }}/{{ etcd_release }}/{{ item }} {{ etcd_dir }}
+- name: Copy binaries from archive into etcd dir
+  command: rsync -auv --out-format='<<CHANGED>>%i %n%L' {{ etcd_download_dir }}/{{ etcd_release }}/{{ item }} {{ etcd_dir }}
+  register: etcd_rsync_out
+  changed_when: etcd_rsync_out.stdout | search("CHANGED")
   with_items:
     - etcd
     - etcdctl
 
-- name: etcd upstart service
+- name: Add etcd upstart service
   template: src=etc/init/etcd.conf.j2
             dest=/etc/init/etcd.conf
             mode=0644
   when: ansible_os_family == "Debian"
   notify:
-    - restart etcd
+    - Restart etcd
 
-- name: etcd systemd service
+- name: Add etcd systemd service
   template: src=etc/systemd/system/etcd.j2
             dest=/etc/systemd/system/etcd.service
             mode=0644
   when: ansible_os_family == "RedHat"
   notify:
-    - restart etcd
+    - Restart etcd


### PR DESCRIPTION
Ansible doesn't have a nice system to system copy module.  Updated the rsync
command to be idempotent.

    TASK: [ansible-etcd | Copy binaries from archive into etcd dir] ***************

    ok: [etcd-02] => (item=etcd)

    ok: [etcd-01] => (item=etcd)

    ok: [etcd-03] => (item=etcd)

    ok: [etcd-02] => (item=etcdctl)

    ok: [etcd-03] => (item=etcdctl)

    ok: [etcd-01] => (item=etcdctl)