### PR TITLE
Added ubuntu upstart system

### DIFF
--- a/molecule.yml
+++ b/molecule.yml
@@ -31,3 +31,13 @@ docker:
         - etcd
       image: solita/ubuntu-systemd
       image_version: latest
+    - name: etcd-05
+      ansible_groups:
+        - etcd
+      image: ubuntu-upstart
+      image_version: latest
+    - name: etcd-06
+      ansible_groups:
+        - etcd
+      image: ubuntu-upstart
+      image_version: latest

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -16,4 +16,4 @@ def test_cluster_configured(Interface, Command):
            'grep -o 2379 | '
            'wc -l').format(address)
 
-    assert Command.check_output(cmd) == '4'
+    assert Command.check_output(cmd) == '6'


### PR DESCRIPTION
We are now validating we can spin up a multi platform cluster across
ubuntu, rhel, systemd, and upstart.